### PR TITLE
Update the make-db interface to accept a different max-size from the default

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject clj-lmdb "0.2.0"
+(defproject clj-lmdb "0.2.1"
   :description "Clojure bindings for lmdb"
   :url "http://github.com/shriphani/clj-lmdb"
   :license {:name "Eclipse Public License"

--- a/src/clj_lmdb/core.clj
+++ b/src/clj_lmdb/core.clj
@@ -7,10 +7,16 @@
 (defrecord Txn [txn type])
 
 (defn make-db
-  [dir-path]
-  (let [env (Env. dir-path)
-        db  (.openDatabase env)]
-   (DB. env db)))
+  "Initialize a new database, optionally specifying *max-size*, in
+  bytes. By default, the maximum size of the memory map (and thus the
+  database) is 10485760 bytes."
+  ([dir-path max-size]
+   (let [env (doto (Env. dir-path)
+               (.setMapSize max-size))
+         db  (.openDatabase env)]
+     (DB. env db)))
+  ([dir-path]
+   (make-db dir-path 10485760)))
 
 (defn read-txn
   [db-record]


### PR DESCRIPTION
The default maximum memory map is just a tad over 10 MB, which is miniscule
for many purposes. This change adds an optional argument to **make-db** which
allows the caller to specify a different maximum size in bytes.
