### PR TITLE
Reintroduce the original byte[] arguments to all interfaces

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Clojure wrappers for lmdb - the best no-nonsense, no-surprise, fast key-value st
 `make-db`
 
 ```clojure
-(use 'clj-lmdb.core :reload)
+(use 'clj-lmdb.simple :reload)
 nil
 user> (def db (make-db "/tmp"))
 #'user/db
@@ -104,7 +104,7 @@ to iterate over the entries or to iterate from a particular key onwards.
     (items-from db txn "foo")))))
 ```
 
-For more examples, see the [tests](test/clj_lmdb/core_test.clj)
+For more examples, see the [tests](test/clj_lmdb/simple_test.clj)
 
 ## LICENSE
 

--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject clj-lmdb "0.2.1"
+(defproject clj-lmdb "0.2.3"
   :description "Clojure bindings for lmdb"
   :url "http://github.com/shriphani/clj-lmdb"
   :license {:name "Eclipse Public License"

--- a/src/clj_lmdb/core.clj
+++ b/src/clj_lmdb/core.clj
@@ -1,6 +1,5 @@
 (ns clj-lmdb.core
-  (:import [org.fusesource.lmdbjni Database Env]
-           [org.fusesource.lmdbjni Constants]))
+  (:import [org.fusesource.lmdbjni Database Env]))
 
 (defrecord DB [env db])
 
@@ -56,72 +55,64 @@
    (let [db (:db db-record)]
      (.put db
            (:txn txn)
-           (Constants/bytes k)
-           (Constants/bytes v))))
+           k
+           v)))
 
   ([db-record k v]
    (let [db (:db db-record)]
      (.put db
-           (Constants/bytes k)
-           (Constants/bytes v)))))
+           k
+           v))))
 
 (defn get!
   ([db-record txn k]
    (let [db (:db db-record)]
-     (Constants/string
-      (.get db
-            (:txn txn)
-            (Constants/bytes k)))))
+     (.get db
+           (:txn txn)
+           k)))
   
   ([db-record k]
    (let [db (:db db-record)]
-     (Constants/string
-      (.get db
-            (Constants/bytes k))))))
+     (.get db
+           k))))
 
 (defn delete!
   ([db-record txn k]
    (let [db (:db db-record)]
      (.delete db
               (:txn txn)
-              (Constants/bytes k))))
+              k)))
 
   ([db-record k]
    (let [db (:db db-record)]
     (.delete db
-             (Constants/bytes k)))))
+             k))))
 
 
 (defn items
   [db-record txn]
   (let [db   (:db db-record)
         txn* (:txn txn)
-        
+
         entries (-> db
                     (.iterate txn*)
                     iterator-seq)]
     (map
      (fn [e]
-       (let [k (.getKey e)
-             v (.getValue e)]
-         [(Constants/string k)
-          (Constants/string v)]))
+       [(.getKey e) (.getValue e)])
      entries)))
 
 (defn items-from
   [db-record txn from]
   (let [db   (:db db-record)
         txn* (:txn txn)
-        
+
         entries (-> db
                     (.seek txn*
-                           (Constants/bytes from))
+                           from)
                     iterator-seq)]
     (map
      (fn [e]
-       (let [k (.getKey e)
-             v (.getValue e)]
-         [(Constants/string k)
-          (Constants/string v)]))
+       [(.getKey e) (.getValue e)])
      entries)))
  

--- a/src/clj_lmdb/simple.clj
+++ b/src/clj_lmdb/simple.clj
@@ -1,0 +1,45 @@
+(ns clj-lmdb.simple
+  (:require [clj-lmdb.core :as core])
+  (:import [org.fusesource.lmdbjni Constants]))
+
+(def make-db core/make-db)
+(def read-txn core/read-txn)
+(def write-txn core/write-txn)
+
+(defmacro with-txn
+  [& args]
+  `(core/with-txn ~@args))
+
+(defn put!
+  ([db-record txn k v]
+   (core/put! db-record txn (Constants/bytes k) (Constants/bytes v)))
+  ([db-record k v]
+   (core/put! db-record (Constants/bytes k) (Constants/bytes v))))
+
+(defn get!
+  ([db-record txn k]
+   (->> (Constants/bytes k)
+        (core/get! db-record txn)
+        (Constants/string)))
+  ([db-record k]
+   (->> (Constants/bytes k)
+        (core/get! db-record)
+        (Constants/string))))
+
+(defn delete!
+  ([db-record txn k]
+   (core/delete! db-record txn (Constants/bytes k)))
+  ([db-record k]
+   (core/delete! db-record (Constants/bytes k))))
+
+(defn items
+  [db-record txn]
+  (->> (core/items db-record txn)
+       (map (fn [[k v]] [(Constants/string k) (Constants/string v)]))))
+
+(defn items-from
+  [db-record txn from]
+  (->> (Constants/bytes from)
+       (core/items-from db-record txn)
+       (map (fn [[k v]] [(Constants/string k) (Constants/string v)]))))
+ 

--- a/test/clj_lmdb/simple_test.clj
+++ b/test/clj_lmdb/simple_test.clj
@@ -1,6 +1,6 @@
-(ns clj-lmdb.core-test
+(ns clj-lmdb.simple-test
   (:require [clojure.test :refer :all]
-            [clj-lmdb.core :refer :all]))
+            [clj-lmdb.simple :refer :all]))
 
 (deftest non-txn-test
   (testing "Put + get without using a txn"


### PR DESCRIPTION
Remove the requirement that all fields be strings. Serialization
and I/O should ideally live at separate layers. This frees up
calling code to use different marshalling libraries, depending on
clients' differing speed and storage needs.
